### PR TITLE
Improve number handling with latin and cyrillic support

### DIFF
--- a/kaalin/number/__init__.py
+++ b/kaalin/number/__init__.py
@@ -1,2 +1,2 @@
-from .number import Number
+from .number import NumberLatin, NumberCyrillic
 from .exceptions import NumberRangeError

--- a/kaalin/number/number.py
+++ b/kaalin/number/number.py
@@ -2,108 +2,86 @@ from .exceptions import NumberRangeError
 
 
 class Number:
-  __ones = ["", "bir", "eki", "úsh", "tórt", "bes", "altı", "jeti", "segiz", "toǵız", "on", "on bir", "on eki", "on úsh", "on tórt", "on bes",
-            "on altı", "on jeti", "on segiz", "on toǵız"]
-  __tens = ["", "", "jigirma", "otız", "qırıq", "eliw", "alpıs", "jetpis", "seksen", "toqsan"]
+  _NUM_TYPE_LAT = 'lat'
+  _NUM_TYPE_CYR = 'cyr'
+  _KEY_ONES = 'ones'
+  _KEY_TEENS = 'teens'
+  _KEY_TENS = 'tens'
+  _KEY_HUNDRED = 'hundred'
+  _KEY_THOUSANDS = 'thousands'
 
-  def __init__(self):
-    pass
+  _locale = {
+    _NUM_TYPE_LAT: {
+      _KEY_ONES: ['nol', 'bir', 'eki', 'úsh', 'tórt', 'bes', 'altı', 'jeti', 'segiz', 'toǵız'],
+      _KEY_TEENS: ['on bir', 'on eki', 'on úsh', 'on tórt', 'on bes', 'on altı', 'on jeti', 'on segiz', 'on toǵız'],
+      _KEY_TENS: ['on', 'jigirma', 'otız', 'qırıq', 'eliw', 'alpıs', 'jetpis', 'seksen', 'toqsan'],
+      _KEY_THOUSANDS: ['', 'mıń', 'million', 'milliard', 'trillion', 'kvadrillion', 'kvintillion', 'sekstilion', 'septillion', 'oktillion', 'nonillion'],
+      _KEY_HUNDRED: 'júz',
+    },
+    _NUM_TYPE_CYR: {
+      _KEY_ONES: ['ноль', 'бир', 'еки', 'үш', 'төрт', 'бес', 'алты', 'жети', 'сегиз', 'тоғыз'],
+      _KEY_TEENS: ['он бир', 'он еки', 'он үш', 'он төрт', 'он бес', 'он алты', 'он жети', 'он сегиз', 'он тоғыз'],
+      _KEY_TENS: ['он', 'жигирма', 'отыз', 'қырық', 'елиў', 'алпыс', 'жетпис', 'сексен', 'тоқсан'],
+      _KEY_THOUSANDS: ['', 'мың', 'миллион', 'миллиард', 'триллион', 'квадриллион', 'квинтиллион', 'секстиллион', 'септиллион', 'октиллион',
+                       'нониллион'],
+      _KEY_HUNDRED: 'жүз',
+    }
+  }
+  _current_locale = None
 
-  def to_word(self, number):
-    if number < 20:
-      return self.__ones[number]
-    elif number < 100:
-      ten_digit = number // 10
-      one_digit = number % 10
-      if one_digit == 0:
-        return self.__tens[ten_digit]
+  def __init__(self, num_type=_NUM_TYPE_LAT):
+    self._current_locale = self._locale[num_type]
+
+  def to_words(self, number):
+    """
+    Convert an integer to its text representation
+    :param number: The integer to convert
+    :return: The textual representation of the integer
+    """
+
+    ones = self._current_locale[self._KEY_ONES]
+    teens = self._current_locale[self._KEY_TEENS]
+    tens = self._current_locale[self._KEY_TENS]
+    thousands = self._current_locale[self._KEY_THOUSANDS]
+
+    def convert_hundreds(num):
+      if num < 10:
+        return ones[num]
+      elif 10 < num < 20:
+        return teens[num - 11]
+      elif num < 100:
+        return tens[num // 10 - 1] + (" " + ones[num % 10] if num % 10 != 0 else "")
       else:
-        return f"{self.__tens[ten_digit]} {self.__ones[one_digit]}"
-    elif number < 1_000:
-      hundred_digit = number // 100
-      remainder = number % 100
-      if remainder == 0:
-        if hundred_digit == 1:
-          return "júz"
-        return f"{self.__ones[hundred_digit]} júz"
-      else:
-        return f"{self.__ones[hundred_digit]} júz {self.to_word(remainder)}"
-    elif number < 10_000:
-      thousand_digit = number // 1000
-      remainder = number % 1000
-      if remainder == 0:
-        return f"mıń"
-      else:
-        return f"{self.to_word(thousand_digit)} mıń {self.to_word(remainder)}"
-    elif number < 1_000_000:
-      ten_thousand_digit = number // 1000
-      remainder = number % 1000
-      if remainder == 0:
-        return f"{self.to_word(ten_thousand_digit)} mıń"
-      else:
-        return f"{self.to_word(ten_thousand_digit)} mıń {self.to_word(remainder)}"
-    elif number < 1_000_000_000:
-      million_digit = number // 1_000_000
-      remainder = number % 1_000_000
-      if remainder == 0:
-        return f"{self.to_word(million_digit)} million"
-      else:
-        return f"{self.to_word(million_digit)} million {self.to_word(remainder)}"
-    elif number < 1_000_000_000_000:
-      billion_digit = number // 1_000_000_000
-      remainder = number % 1_000_000_000
-      if remainder == 0:
-        return f"{self.to_word(billion_digit)} milliard"
-      else:
-        return f"{self.to_word(billion_digit)} milliard {self.to_word(remainder)}"
-    elif number < 1_000_000_000_000_000:
-      trillion_digit = number // 1_000_000_000_000
-      remainder = number % 1_000_000_000_000
-      if remainder == 0:
-        return f"{self.to_word(trillion_digit)} trillion"
-      else:
-        return f"{self.to_word(trillion_digit)} trillion {self.to_word(remainder)}"
-    elif number < 1_000_000_000_000_000_000:
-      quadrillion_digit = number // 1_000_000_000_000_000
-      remainder = number % 1_000_000_000_000_000
-      if remainder == 0:
-        return f"{self.to_word(quadrillion_digit)} kvadrillion"
-      else:
-        return f"{self.to_word(quadrillion_digit)} kvadrillion {self.to_word(remainder)}"
-    elif number < 1_000_000_000_000_000_000_000:
-      quantillion_digit = number // 1_000_000_000_000_000_000
-      remainder = number % 1_000_000_000_000_000_000
-      if remainder == 0:
-        return f"{self.to_word(quantillion_digit)} kvintillion"
-      else:
-        return f"{self.to_word(quantillion_digit)} kvintillion {self.to_word(remainder)}"
-    elif number < 1_000_000_000_000_000_000_000_000:
-      sextillion_digit = number // 1_000_000_000_000_000_000_000
-      remainder = number % 1_000_000_000_000_000_000_000
-      if remainder == 0:
-        return f"{self.to_word(sextillion_digit)} sekstilion"
-      else:
-        return f"{self.to_word(sextillion_digit)} sekstilion {self.to_word(remainder)}"
-    elif number < 1_000_000_000_000_000_000_000_000_000:
-      septillion_digit = number // 1_000_000_000_000_000_000_000_000
-      remainder = number % 1_000_000_000_000_000_000_000_000
-      if remainder == 0:
-        return f"{self.to_word(septillion_digit)} septillion"
-      else:
-        return f"{self.to_word(septillion_digit)} septillion {self.to_word(remainder)}"
-    elif number < 1_000_000_000_000_000_000_000_000_000_000:
-      octillion_digit = number // 1_000_000_000_000_000_000_000_000_000
-      remainder = number % 1_000_000_000_000_000_000_000_000_000
-      if remainder == 0:
-        return f"{self.to_word(octillion_digit)} oktillion"
-      else:
-        return f"{self.to_word(octillion_digit)} oktillion {self.to_word(remainder)}"
-    elif number < 1_000_000_000_000_000_000_000_000_000_000_000:
-      nonillion_digit = number // 1_000_000_000_000_000_000_000_000_000_000
-      remainder = number % 1_000_000_000_000_000_000_000_000_000_000
-      if remainder == 0:
-        return f"{self.to_word(nonillion_digit)} nonillion"
-      else:
-        return f"{self.to_word(nonillion_digit)} nonillion {self.to_word(remainder)}"
+        return ones[num // 100] + f" {self._current_locale[self._KEY_HUNDRED]}" + (" " + convert_hundreds(num % 100) if num % 100 != 0 else "")
+
+    def convert_number(num):
+      if num == 0:
+        return ones[num]
+      if num == 100:
+        return self._current_locale[self._KEY_HUNDRED]
+      if num == 1000:
+        return thousands[1]
+
+      parts = []
+      i = 0
+      while num > 0:
+        if num % 1000 != 0:
+          parts.append(convert_hundreds(num % 1000) + (" " + thousands[i] if thousands[i] else ""))
+        num //= 1000
+        i += 1
+      return " ".join(reversed(parts))
+
+    if isinstance(number, int):
+      return convert_number(number)
     else:
-      raise NumberRangeError()
+      raise NumberRangeError
+
+
+class NumberLatin(Number):
+  def __init__(self):
+    super().__init__(self._NUM_TYPE_LAT)
+
+
+class NumberCyrillic(Number):
+  def __init__(self):
+    super().__init__(self._NUM_TYPE_CYR)

--- a/test/test_kaalin_number.py
+++ b/test/test_kaalin_number.py
@@ -1,15 +1,33 @@
 import unittest
-from kaalin.number import Number
+
+from kaalin.number.number import NumberLatin, NumberCyrillic
 
 
 class TestKaalinNumber(unittest.TestCase):
-  def setUp(self):
-    self.kn = Number()
 
-  def test_to_word(self):
-    self.assertEqual(self.kn.to_word(5), "bes")
-    self.assertEqual(self.kn.to_word(27), "jigirma jeti")
-    self.assertEqual(self.kn.to_word(1000), "mıń")
+  def test_to_word_latin(self):
+    self.kn = NumberLatin()
+    self.assertEqual(self.kn.to_words(5), "bes")
+    self.assertEqual(self.kn.to_words(10), "on")
+    self.assertEqual(self.kn.to_words(27), "jigirma jeti")
+    self.assertEqual(self.kn.to_words(60), "alpıs")
+    self.assertEqual(self.kn.to_words(100), "júz")
+    self.assertEqual(self.kn.to_words(1_000), "mıń")
+    self.assertEqual(self.kn.to_words(1_590), "bir mıń bes júz toqsan")
+    self.assertEqual(self.kn.to_words(39_406), "otız toǵız mıń tórt júz altı")
+    self.assertEqual(self.kn.to_words(1_000_000), "bir million")
+    self.assertEqual(self.kn.to_words(117_790_283), "bir júz on jeti million jeti júz toqsan mıń eki júz seksen úsh")
+    self.assertEqual(self.kn.to_words(1_000_000_000), "bir milliard")
+    self.assertEqual(self.kn.to_words(303_019_867_115), "úsh júz úsh milliard on toǵız million segiz júz alpıs jeti mıń bir júz on bes")
+
+  def test_to_word_cyrillic(self):
+    self.kn = NumberCyrillic()
+    self.assertEqual(self.kn.to_words(8), "сегиз")
+    self.assertEqual(self.kn.to_words(61), "алпыс бир")
+    self.assertEqual(self.kn.to_words(5_000), "бес мың")
+    self.assertEqual(self.kn.to_words(965_713), "тоғыз жүз алпыс бес мың жети жүз он үш")
+    self.assertEqual(self.kn.to_words(497_781_216), "төрт жүз тоқсан жети миллион жети жүз сексен бир мың еки жүз он алты")
+    self.assertEqual(self.kn.to_words(294_619_742_229),"еки жүз тоқсан төрт миллиард алты жүз он тоғыз миллион жети жүз қырық еки мың еки жүз жигирма тоғыз")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Add latin and cyrillic support
- Update `Number`'s `to_words` function, thanks to all mighty ChatGPT, it is reduced in size
- Create separate `NumberLatin` and `NumberCyrillic` instances to hide the implementation details of `Number` class