### PR TITLE
Simplify Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,9 @@ from kaalin.string import upper, lower
 print(upper("Assalawma áleykum")) 	  # ASSALAWMA ÁLEYKUM
 print(lower("Assalawma áleykum"))     # assalawma áleykum
 ```
+```python
+from kaalin.number import to_word
+
+print(to_word(2025))
+print(to_word(2025, num_type='cyr'))
+```

--- a/kaalin/number/__init__.py
+++ b/kaalin/number/__init__.py
@@ -1,2 +1,3 @@
 from .number import NumberLatin, NumberCyrillic
 from .exceptions import NumberRangeError
+from .num2words import to_word

--- a/kaalin/number/exceptions.py
+++ b/kaalin/number/exceptions.py
@@ -1,4 +1,4 @@
 class NumberRangeError(Exception):
-  def __init__(self, message="San shegaradan asıp ketti, maksimum decillion (1 000 000 000 000 000 000 000 000 000 000 000)"):
+  def __init__(self, message="Number exceeded limit"):
     self.message = message
     super().__init__(self.message)

--- a/kaalin/number/num2words.py
+++ b/kaalin/number/num2words.py
@@ -41,6 +41,9 @@ def to_word(number: int, num_type: str = "lat") -> str:
         }
     }
     
+    if num_type not in ['lat', 'cyr']:
+        raise KeyError("Invalid num_type")
+    
     if not isinstance(number, int):
         raise TypeError("Input must be an integer")
         

--- a/kaalin/number/num2words.py
+++ b/kaalin/number/num2words.py
@@ -1,0 +1,85 @@
+from .exceptions import NumberRangeError
+
+
+def to_word(number: int, num_type: str = "lat") -> str:
+    """
+    Convert an integer to its text representation in either Latin or Cyrillic script.
+    
+    Args:
+        number: The integer to convert
+        num_type: The type of script to use, either "lat" or "cyr"
+        
+    Returns:
+        The textual representation of the integer
+        
+    Raises:
+        NumberRangeError: If the input is not an integer or exceeds the maximum supported number (nonillion)
+    """
+
+    _NUM_TYPE_LAT = 'lat'
+    _NUM_TYPE_CYR = 'cyr'
+    _KEY_ONES = 'ones'
+    _KEY_TEENS = 'teens'
+    _KEY_TENS = 'tens'
+    _KEY_HUNDRED = 'hundred'
+    _KEY_THOUSANDS = 'thousands'
+
+    _locale = {
+        _NUM_TYPE_LAT: {
+            _KEY_ONES: ['nol', 'bir', 'eki', 'úsh', 'tórt', 'bes', 'altı', 'jeti', 'segiz', 'toǵız'],
+            _KEY_TEENS: ['on bir', 'on eki', 'on úsh', 'on tórt', 'on bes', 'on altı', 'on jeti', 'on segiz', 'on toǵız'],
+            _KEY_TENS: ['on', 'jigirma', 'otız', 'qırıq', 'eliw', 'alpıs', 'jetpis', 'seksen', 'toqsan'],
+            _KEY_THOUSANDS: ['', 'mıń', 'million', 'milliard', 'trillion', 'kvadrillion', 'kvintillion', 'sekstilion', 'septillion', 'oktillion', 'nonillion'],
+            _KEY_HUNDRED: 'júz',
+        },
+        _NUM_TYPE_CYR: {
+            _KEY_ONES: ['ноль', 'бир', 'еки', 'үш', 'төрт', 'бес', 'алты', 'жети', 'сегиз', 'тоғыз'],
+            _KEY_TEENS: ['он бир', 'он еки', 'он үш', 'он төрт', 'он бес', 'он алты', 'он жети', 'он сегиз', 'он тоғыз'],
+            _KEY_TENS: ['он', 'жигирма', 'отыз', 'қырық', 'елиў', 'алпыс', 'жетпис', 'сексен', 'тоқсан'],
+            _KEY_THOUSANDS: ['', 'мың', 'миллион', 'миллиард', 'триллион', 'квадриллион', 'квинтиллион', 'секстиллион', 'септиллион', 'октиллион', 'нониллион'],
+            _KEY_HUNDRED: 'жүз',
+        }
+    }
+    
+    if not isinstance(number, int):
+        raise TypeError("Input must be an integer")
+        
+    # Check if number exceeds nonillion (10^30)
+    if abs(number) > 10**30:
+        raise NumberRangeError("Number exceeded limit")
+    
+    current_locale = _locale[_NUM_TYPE_CYR] if num_type == _NUM_TYPE_CYR else _locale[_NUM_TYPE_LAT]
+    
+    ones = current_locale[_KEY_ONES]
+    teens = current_locale[_KEY_TEENS]
+    tens = current_locale[_KEY_TENS]
+    thousands = current_locale[_KEY_THOUSANDS]
+
+    def convert_hundreds(num):
+        if num < 10:
+            return ones[num]
+        elif 10 < num < 20:
+            return teens[num - 11]
+        elif num < 100:
+            return tens[num // 10 - 1] + (" " + ones[num % 10] if num % 10 != 0 else "")
+        else:
+            return ones[num // 100] + f" {current_locale[_KEY_HUNDRED]}" + (" " + convert_hundreds(num % 100) if num % 100 != 0 else "")
+
+    def convert_number(num):
+        if num == 0:
+            return ones[num]
+        if num == 100:
+            return current_locale[_KEY_HUNDRED]
+        if num == 1000:
+            return thousands[1]
+
+        parts = []
+        i = 0
+        while num > 0:
+            if num % 1000 != 0:
+                parts.append(convert_hundreds(num % 1000) + (" " + thousands[i] if thousands[i] else ""))
+            num //= 1000
+            i += 1
+        return " ".join(reversed(parts))
+
+    return convert_number(number)

--- a/kaalin/number/number.py
+++ b/kaalin/number/number.py
@@ -78,10 +78,14 @@ class Number:
 
 
 class NumberLatin(Number):
+  """**Deprecated**: This class may be deprecated in the future."""
+  
   def __init__(self):
     super().__init__(self._NUM_TYPE_LAT)
 
 
 class NumberCyrillic(Number):
+  """**Deprecated**: This class may be deprecated in the future."""
+  
   def __init__(self):
     super().__init__(self._NUM_TYPE_CYR)

--- a/test/test_num2words.py
+++ b/test/test_num2words.py
@@ -1,0 +1,67 @@
+import pytest
+from kaalin.number.num2words import to_word
+from kaalin.number.exceptions import NumberRangeError
+
+
+def test_basic_numbers_latin():
+    assert to_word(0) == "nol"
+    assert to_word(1) == "bir"
+    assert to_word(5) == "bes"
+    assert to_word(10) == "on"
+    assert to_word(11) == "on bir"
+    assert to_word(20) == "jigirma"
+    assert to_word(25) == "jigirma bes"
+    assert to_word(100) == "júz"
+    assert to_word(101) == "bir júz bir"
+
+
+def test_basic_numbers_cyrillic():
+    assert to_word(0, "cyr") == "ноль"
+    assert to_word(1, "cyr") == "бир"
+    assert to_word(5, "cyr") == "бес"
+    assert to_word(10, "cyr") == "он"
+    assert to_word(11, "cyr") == "он бир"
+    assert to_word(20, "cyr") == "жигирма"
+    assert to_word(25, "cyr") == "жигирма бес"
+    assert to_word(100, "cyr") == "жүз"
+    assert to_word(101, "cyr") == "бир жүз бир"
+
+
+def test_large_numbers():
+    assert to_word(1000000) == "bir million"
+    assert to_word(1000000000) == "bir milliard"
+    assert to_word(1000000000000) == "bir trillion"
+    assert to_word(10**30) == "bir nonillion"  # Maximum supported number
+
+
+def test_error_cases():
+    # Test non-integer input
+    with pytest.raises(TypeError):
+        to_word("123")
+    
+    with pytest.raises(TypeError):
+        to_word(123.45)
+    
+    # Test number exceeding limit
+    with pytest.raises(NumberRangeError):
+        to_word(10**30 + 1)
+    
+    with pytest.raises(NumberRangeError):
+        to_word(-10**30 - 1)
+    
+    # Test invalid num_type
+    with pytest.raises(KeyError):
+        to_word(123, "invalid")
+
+
+def test_special_cases():
+    # Test numbers with multiple thousands
+    assert to_word(1000000) == "bir million"
+    assert to_word(1000001) == "bir million bir"
+    assert to_word(1001000) == "bir million bir mıń"
+    assert to_word(1001001) == "bir million bir mıń bir"
+    
+    # Test numbers with hundreds and thousands
+    assert to_word(1100) == "bir mıń bir júz"
+    assert to_word(1101) == "bir mıń bir júz bir"
+    assert to_word(1111) == "bir mıń bir júz on bir" 


### PR DESCRIPTION
Some changes were implemented to enhance ease of use. A new `to_word` function was created to perform the tasks of the `NumberLatin` and `NumberCyrillic` classes.

After making changes, the following method can be used to convert a number to text:

```python
from kaalin.number import to_word

print(to_word(2025))
print(to_word(2025, num_type='cyr'))
```