### PR TITLE
CLI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ from kaalin.string import upper, lower
 print(upper("Assalawma áleykum"))     # ASSALAWMA ÁLEYKUM
 print(lower("Assalawma áleykum"))     # assalawma áleykum
 ```
+
+### Command Line Interface (CLI)
+```bash
+$ cyr2lat input.txt [output.txt]
+$ lat2cyr input.txt [output.txt]
+```

--- a/kaalin/__init__.py
+++ b/kaalin/__init__.py
@@ -1,3 +1,4 @@
 from .number import NumberRangeError
 from .converter import latin2cyrillic, cyrillic2latin
 from . import string
+from . import cli

--- a/kaalin/cli/__init__.py
+++ b/kaalin/cli/__init__.py
@@ -1,0 +1,1 @@
+from .converter import lat2cyr, cyr2lat

--- a/kaalin/cli/converter.py
+++ b/kaalin/cli/converter.py
@@ -1,0 +1,52 @@
+from kaalin.converter.latin_cyrillic_converter import latin2cyrillic, cyrillic2latin
+import sys
+import os
+
+def cyr2lat():
+    if len(sys.argv) < 2 or len(sys.argv) > 3:
+        print("Use:\n  cyr2lat <input_file> [output_file]")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+
+    if len(sys.argv) == 3:
+        output_file = sys.argv[2]
+    else:
+        base, ext = os.path.splitext(input_file)
+        output_file = f"{base}-lat{ext}"
+
+    try:
+        with open(input_file, "r", encoding="utf-8") as f:
+            text = f.read()
+        converted = cyrillic2latin(text)
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(converted)
+        print(f"✅ Converted text written to: {output_file}")
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        sys.exit(1)
+
+
+def lat2cyr():
+    if len(sys.argv) < 2 or len(sys.argv) > 3:
+        print("Use:\n  lat2cyr <input_file> [output_file]")
+        sys.exit(1)
+
+    input_file = sys.argv[1]
+
+    if len(sys.argv) == 3:
+        output_file = sys.argv[2]
+    else:
+        base, ext = os.path.splitext(input_file)
+        output_file = f"{base}-cyr{ext}"
+
+    try:
+        with open(input_file, "r", encoding="utf-8") as f:
+            text = f.read()
+        converted = latin2cyrillic(text)
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(converted)
+        print(f"✅ Converted text written to: {output_file}")
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '3.0.1'
+VERSION = '3.1.0'
 DESCRIPTION = 'Special opportunities for the Karakalpak language'
 
 # Setting up
@@ -21,6 +21,12 @@ setup(
     long_description=long_description,
     packages=find_packages(),
     install_requires=[],
+    entry_points={
+      "console_scripts": [
+          "cyr2lat=kaalin.cli.converter:cyr2lat",
+          "lat2cyr=kaalin.cli.converter:lat2cyr",
+      ]
+    },
     keywords=['karakalpak', 'language', 'python'],
     classifiers=[
         "Development Status :: 1 - Planning",


### PR DESCRIPTION
This PR enhances the `cyr2lat` and `lat2cyr` CLI tools by:
 - Allowing an optional second argument to specify the output file.
 - Automatically generating the output filename if not provided (e.g., input.txt → input-lat.txt or input-cyr.txt).
 - Displaying a helpful usage message when no arguments are passed.
 
### Usage examples:
```shell
cyr2lat input.txt               # Output: input-lat.txt
lat2cyr input.txt output.txt    # Output: output.txt
cyr2lat                         # Shows usage message
```